### PR TITLE
ci: add cuncurrency to GitHub Actions workflow [skip ci]

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   support:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   support:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
#### Why

This adds a concurrency group to GitHub Actions workflows.

More info on what it is can be found [here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)
